### PR TITLE
Switch to Ubuntu 16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:wily
+FROM ubuntu:16.04
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
The wily archives are apparently no longer available from http://archive.ubuntu.com/ubuntu/dists/ making any image based the current tag fail on `apt-get update` - see https://hub.docker.com/r/openmicroscopy/octave/builds/bgdwp69wgtm4nu4e2ezqdok/ or https://hub.docker.com/r/snoopycrimecop/bio-formats-octave/builds/bc7uibef34sanxkpmyhx8yy/

This PR updates the base image of the Octave container to the LTS Ubuntu 16.04. In addition to restoring the various builds, this makes it consistent with the rest of the project. Proposed tag: `0.2.0`