### PR TITLE
Bump base image to Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install less
+RUN apt-get update \
+    && apt-get install less \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
 ADD install.sh install.sh
 RUN sh ./install.sh && rm install.sh
 RUN useradd -ms /bin/bash octave


### PR DESCRIPTION
This should install Octave 4.2 and allow to test pre-release versions of Bio-Formats - see https://github.com/openmicroscopy/bio-formats-octave-docker/pull/26

Proposed tag: `0.3.0`